### PR TITLE
re-invest profits

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -707,6 +707,7 @@ def sell_coins(tpsl_override = False, specific_coin_to_sell = ""):
     '''sell coins that have reached the STOP LOSS or TAKE PROFIT threshold'''
     global hsp_head, session_profit_incfees_perc, session_profit_incfees_total, coin_order_id, trade_wins, trade_losses, historic_profit_incfees_perc, historic_profit_incfees_total, sell_all_coins, sell_specific_coin
     
+    global TRADE_TOTAL
     externals = sell_external_signals()
     
     last_price = get_price(False) # don't populate rolling window
@@ -884,6 +885,8 @@ def sell_coins(tpsl_override = False, specific_coin_to_sell = ""):
                 #write_log(f"\tSell\t{coin}\t{coins_sold[coin]['volume']}\t{BuyPrice}\t{PAIR_WITH}\t{LastPrice}\t{profit_incfees_total:.{decimals()}f}\t{PriceChange_Perc:.2f}\t{sell_reason}")
                 write_log(f"\tSell\t{coin}\t{coins_sold[coin]['volume']}\t{BuyPrice}\t{PAIR_WITH}\t{LastPrice}\t{profit_incfees_total:.{decimals()}f}\t{PriceChangeIncFees_Perc:.2f}\t{sell_reason}")
                 
+                # re-invest profit
+                TRADE_TOTAL += profit_incfees_total
                 #this is good
                 session_profit_incfees_total = session_profit_incfees_total + profit_incfees_total
                 session_profit_incfees_perc = session_profit_incfees_perc + ((profit_incfees_total/BUDGET) * 100)


### PR DESCRIPTION

### What are you addressing in this PR

  - [X] Functionality 
  - [ ] Ease of use   
  - [ ] Bug fix       

### How have you tested this PR

tested both in test mode and in live mode, however, any mode would be enough here as the change is not directly linked to any particular running mode.

### In your own words, please share how this makes the codebase better.
well, it doesn't really. The codebase is quite a mess due to the BVT original repo not having any tests. What this does is change the original behaviour so that the bot re-invests all the profits (and losses) throughout its current session.
 
so that the bot on a 1% daily return, would return something along the lines of:
https://www.thecalculatorsite.com/dailycompound?a=100&p=1&pp=daily&y=1&m=0&d=0&dr=100&iw=y&dw=y&md=0&rp=monthly&sd=2021-11-29&c=1